### PR TITLE
Fix: correct package exports syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@bbc/web-vitals",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "exports": {
     ".": {
-      "require": "dist/index.js",
-      "import": "esm/index.js"
+      "require": "./dist/index.js",
+      "import": "./esm/index.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Resolves #32

**Overall change:**

Syntax of exports in package.json has to start with a `./`

**Code changes:**

The current release does not have a fully qualified `exports` field value in the package.json.

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
