### PR TITLE
Remove `fid` web vital as it is no longer supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/web-vitals",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "main": "dist/index.js",
   "module": "esm/index.js",
   "exports": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const webVitalsBase = {
   url: 'current-page-url',
 };
 
-const vitals = { cls: null, lcp: null, fcp: null, ttfb: null };
+const vitals = { cls: null, lcp: null, fcp: null, ttfb: null, inp: null };
 const deviceMetrics = {
   device_mem: null,
   device_cpu: null,

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const webVitalsBase = {
   url: 'current-page-url',
 };
 
-const vitals = { cls: null, fid: null, lcp: null, fcp: null, ttfb: null };
+const vitals = { cls: null, lcp: null, fcp: null, ttfb: null };
 const deviceMetrics = {
   device_mem: null,
   device_cpu: null,
@@ -136,7 +136,6 @@ const useWebVitals = ({
         deviceMemory,
       });
       onCLS(updateWebVitals, { reportAllChanges: true });
-      onFID(updateWebVitals);
       onLCP(updateWebVitals, { reportAllChanges: true });
       onFCP(updateWebVitals);
       onTTFB(updateWebVitals);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -16,11 +16,10 @@ const mockVitalsGet = (name, value) => reportHandler => {
 };
 
 webVitals.onCLS.mockImplementation(mockVitalsGet('CLS', 1));
-webVitals.onFID.mockImplementation(mockVitalsGet('FID', 2));
-webVitals.onLCP.mockImplementation(mockVitalsGet('LCP', 3));
-webVitals.onFCP.mockImplementation(mockVitalsGet('FCP', 4));
-webVitals.onTTFB.mockImplementation(mockVitalsGet('TTFB', 5));
-webVitals.onINP.mockImplementation(mockVitalsGet('INP', 6));
+webVitals.onLCP.mockImplementation(mockVitalsGet('LCP', 2));
+webVitals.onFCP.mockImplementation(mockVitalsGet('FCP', 3));
+webVitals.onTTFB.mockImplementation(mockVitalsGet('TTFB', 4));
+webVitals.onINP.mockImplementation(mockVitalsGet('INP', 5));
 
 let eventListeners = {};
 
@@ -79,7 +78,6 @@ describe('useWebVitals', () => {
       renderHook(() => useWebVitals({ enabled }));
 
       expect(webVitals.onCLS).toHaveBeenCalled();
-      expect(webVitals.onFID).toHaveBeenCalled();
       expect(webVitals.onLCP).toHaveBeenCalled();
       expect(webVitals.onFCP).toHaveBeenCalled();
       expect(webVitals.onTTFB).toHaveBeenCalled();
@@ -181,7 +179,6 @@ describe('useWebVitals', () => {
       renderHook(() => useWebVitals({ enabled, reportingEndpoint }));
 
       expect(webVitals.onCLS).toHaveBeenCalled();
-      expect(webVitals.onFID).toHaveBeenCalled();
       expect(webVitals.onLCP).toHaveBeenCalled();
       expect(webVitals.onFCP).toHaveBeenCalled();
       expect(webVitals.onTTFB).toHaveBeenCalled();
@@ -194,11 +191,10 @@ describe('useWebVitals', () => {
           type: 'web-vitals',
           body: expect.objectContaining({
             cls: 1,
-            fid: 2,
-            lcp: 3,
-            fcp: 4,
-            ttfb: 5,
-            inp: 6,
+            lcp: 2,
+            fcp: 3,
+            ttfb: 4,
+            inp: 5,
           }),
         }),
       ];


### PR DESCRIPTION
**Overall change:** 
Removes references to the `fid` web vital, as according to https://web.dev/articles/fid, support ends on 9th September 2024 

**Code changes:**
- remove fid
- include inp in the metrics sent to the reporting endpoint
- bump version number


---

- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
