### PR TITLE
[WS-367]: bump cross-fetch 3.1.5 --> 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bbc/web-vitals",
-  "version": "2.5.0",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bbc/web-vitals",
-      "version": "2.5.0",
+      "version": "2.5.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.1.0",
         "web-vitals": "^3.3.2"
       },
       "devDependencies": {
@@ -4528,10 +4528,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/bbc/web-vitals/blob/main/README.md",
   "dependencies": {
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^4.1.0",
     "web-vitals": "^3.3.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@ __metadata:
     "@testing-library/user-event": ^14.5.2
     babel-eslint: 10.1.0
     babel-plugin-add-import-extension: ^1.6.0
-    cross-fetch: ^3.1.5
+    cross-fetch: ^4.1.0
     eslint: ^7.10.0
     eslint-config-prettier: ^8.0.0
     eslint-plugin-es5: ^1.5.0
@@ -3112,12 +3112,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.1.5":
-  version: 3.2.0
-  resolution: "cross-fetch@npm:3.2.0"
+"cross-fetch@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cross-fetch@npm:4.1.0"
   dependencies:
     node-fetch: ^2.7.0
-  checksum: 8ded5ea35f705e81e569e7db244a3f96e05e95996ff51877c89b0c1ec1163c76bb5dad77d0f8fba6bb35a0abacb36403d7271dc586d8b1f636110ee7a8d959fd
+  checksum: c02fa85d59f83e50dbd769ee472c9cc984060c403ee5ec8654659f61a525c1a655eef1c7a35e365c1a107b4e72d76e786718b673d1cb3c97f61d4644cb0a9f9d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [WS-367 Web Vitals: cross-fetch dependency](https://bbc.atlassian.net/browse/WS-367)
Subtask of: [Neon | Update Software Dependencies (Timebox)](https://bbc.atlassian.net/browse/WS-363)

**Code changes:**
One of major (red) dependencies requiring a separate PR to be updated:
<img width="739" alt="Babelended by" src="https://github.com/user-attachments/assets/4c872f1d-fbf0-4aa2-8e99-4a70b729a0d9" />