### PR TITLE
Remove cross fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Web Vitals is completely open source. We are grateful for any contributions, whe
 
 ### Code of Conduct
 
+
 We welcome feedback and help on this work. By participating in this project, you agree to abide by the [code of conduct](https://github.com/bbc/web-vitals/blob/latest/.github/CODE_OF_CONDUCT.md). Please take a moment to read it.
 
 ### License

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ npm install --global yarn
 
 ## Props
 
-| Argument          | Type     | Required | Default     | Example                                                       |
-| ----------------- | -------- | -------- | ----------- | ------------------------------------------------------------- |
-| enabled           | Boolean  | No       | false       | `{ enabled: true }`                                           |
-| reportingEndpoint | String   | Yes      | N/A         | `{ reportingEndpoint: 'https://url.to.report.to/analytics' }` |
-| loggerCallback    | Function | No       | `() => {}`  | `{ loggerCallback: (error) => console.error(error) }`         |
-| sampleRate        | Integer  | No       | 100         | `{ sampleRate: 5 }`                                           |
-| reportParams      | Object   | No       | `undefined` | `{ reportParams: { pageType: 'STY' }`                         |
+| Argument          | Type     | Required | Default        | Example                                                                                                 |
+| ----------------- | -------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------- |
+| enabled           | Boolean  | No       | false          | `{ enabled: true }`                                                                                     |
+| reportingEndpoint | String   | Yes      | N/A            | `{ reportingEndpoint: 'https://url.to.report.to/analytics' }`                                           |
+| loggerCallback    | Function | No       | `() => {}`     | `{ loggerCallback: (error) => console.error(error) }`                                                   |
+| sampleRate        | Integer  | No       | 100            | `{ sampleRate: 5 }`                                                                                     |
+| reportParams      | Object   | No       | `undefined`    | `{ reportParams: { pageType: 'STY' }`                                                                   |
+| fetch             | Function | No       | `window.fetch` | Allows you to provide a fetch ponyfill if you support browsers that do not have a native fetch function |
 
 ## Usage
 
@@ -91,7 +92,6 @@ In situations where users have not provided permission for the relevant personal
 Web Vitals is completely open source. We are grateful for any contributions, whether they be new utilities, bug fixes or general improvements. Please see our primary contributing guide which can be found at [the root of the Web Vitals repository](https://github.com/bbc/web-vitals/blob/latest/CONTRIBUTING.md).
 
 ### Code of Conduct
-
 
 We welcome feedback and help on this work. By participating in this project, you agree to abide by the [code of conduct](https://github.com/bbc/web-vitals/blob/latest/.github/CODE_OF_CONDUCT.md). Please take a moment to read it.
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,10 @@
   },
   "homepage": "https://github.com/bbc/web-vitals/blob/main/README.md",
   "dependencies": {
-    "cross-fetch": "^4.1.0",
     "web-vitals": "^3.3.2"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.21.0",

--- a/src/index.js
+++ b/src/index.js
@@ -61,9 +61,7 @@ const sendBeacon = (rawBeacon, reportingEndpoint, reportParams, fetch) => {
 
   if (webVitalsDebug === true) {
     console.log('WEBVITALS DEBUG IS ON');
-    console.log(
-      `In production, WebVitals data would be sent to ${beaconTarget} with the following payload`,
-    );
+    console.log(`In production, WebVitals data would be sent to ${beaconTarget} with the following payload`);
     console.dir(rawBeacon);
     return new Promise((resolve, reject) => {
       resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { useEffect, useState } from 'react';
 import { onCLS, onFID, onLCP, onFCP, onTTFB, onINP } from 'web-vitals';
 
@@ -54,7 +53,7 @@ const appendReportParams = (reportingEndpoint, reportParams) => {
     : `${reportingEndpoint}?${paramsString}`;
 };
 
-const sendBeacon = (rawBeacon, reportingEndpoint, reportParams) => {
+const sendBeacon = (rawBeacon, reportingEndpoint, reportParams, fetch) => {
   const beacon = JSON.stringify(rawBeacon);
   const beaconTarget = reportParams
     ? appendReportParams(reportingEndpoint, reportParams)
@@ -62,10 +61,12 @@ const sendBeacon = (rawBeacon, reportingEndpoint, reportParams) => {
 
   if (webVitalsDebug === true) {
     console.log('WEBVITALS DEBUG IS ON');
-    console.log(`In production, WebVitals data would be sent to ${beaconTarget} with the following payload`);
+    console.log(
+      `In production, WebVitals data would be sent to ${beaconTarget} with the following payload`,
+    );
     console.dir(rawBeacon);
     return new Promise((resolve, reject) => {
-        resolve();
+      resolve();
     });
   }
 
@@ -99,6 +100,7 @@ const useWebVitals = ({
   reportParams,
   webVitalsListener = 'pagehide',
   debug = false,
+  fetch = window.fetch,
 }) => {
   let pageLoadTime;
   webVitalsDebug = debug;
@@ -121,7 +123,7 @@ const useWebVitals = ({
       { ...webVitalsBase, age: pageAge, body: { ...vitals, ...deviceMetrics } },
     ];
 
-    sendBeacon(beacon, reportingEndpoint, reportParams).catch(loggerCallback);
+    sendBeacon(beacon, reportingEndpoint, reportParams, fetch).catch(loggerCallback);
   };
 
   useEvent(webVitalsListener, shouldSendVitals ? sendVitals : noOp);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,13 +1,12 @@
-import fetch from 'cross-fetch';
 import * as webVitals from 'web-vitals';
 import { renderHook } from '@testing-library/react';
 import useWebVitals from './index';
 
-jest.mock('cross-fetch');
+global.fetch = jest.fn();
 jest.mock('web-vitals');
-jest.mock('./lib/use-memory-status.js')
-jest.mock('./lib/use-hardware-concurrency.js')
-jest.mock('./lib/use-network-status.js')
+jest.mock('./lib/use-memory-status.js');
+jest.mock('./lib/use-hardware-concurrency.js');
+jest.mock('./lib/use-network-status.js');
 
 beforeEach(jest.clearAllMocks);
 
@@ -133,6 +132,25 @@ describe('useWebVitals', () => {
         body: expect.any(String),
         mode: 'no-cors',
       });
+    });
+
+    it('uses the provided fetch function in preference to window.fetch when sendBeacon is unavailable', async () => {
+      const customFetch = jest.fn();
+      customFetch.mockImplementation(() => Promise.resolve());
+      renderHook(() =>
+        useWebVitals({ enabled, reportingEndpoint, fetch: customFetch }),
+      );
+
+      await eventListeners.pagehide();
+
+      expect(navigator.sendBeacon).toBeUndefined();
+      expect(customFetch).toHaveBeenCalledWith(reportingEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/reports+json' },
+        body: expect.any(String),
+        mode: 'no-cors',
+      });
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     it('appends the report params as query string parameters to the reporting endpoint if one is provided', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,7 +1434,6 @@ __metadata:
     "@testing-library/user-event": ^14.6.1
     babel-eslint: 10.1.0
     babel-plugin-add-import-extension: ^1.6.0
-    cross-fetch: ^4.1.0
     eslint: ^7.10.0
     eslint-config-prettier: ^8.0.0
     eslint-plugin-es5: ^1.5.0
@@ -1452,7 +1451,7 @@ __metadata:
     shelljs: ^0.8.5
     web-vitals: ^3.3.2
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3110,15 +3109,6 @@ __metadata:
   bin:
     create-jest: bin/create-jest.js
   checksum: 1427d49458adcd88547ef6fa39041e1fe9033a661293aa8d2c3aa1b4967cb5bf4f0c00436c7a61816558f28ba2ba81a94d5c962e8022ea9a883978fc8e1f2945
-  languageName: node
-  linkType: hard
-
-"cross-fetch@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "cross-fetch@npm:4.1.0"
-  dependencies:
-    node-fetch: ^2.7.0
-  checksum: c02fa85d59f83e50dbd769ee472c9cc984060c403ee5ec8654659f61a525c1a655eef1c7a35e365c1a107b4e72d76e786718b673d1cb3c97f61d4644cb0a9f9d
   languageName: node
   linkType: hard
 
@@ -5874,20 +5864,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: ^5.0.0
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:latest":
   version: 11.2.0
   resolution: "node-gyp@npm:11.2.0"
@@ -7464,13 +7440,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -7768,13 +7737,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
-  languageName: node
-  linkType: hard
-
 "webidl-conversions@npm:^7.0.0":
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
@@ -7805,16 +7767,6 @@ __metadata:
     tr46: ^3.0.0
     webidl-conversions: ^7.0.0
   checksum: ed4826aaa57e66bb3488a4b25c9cd476c46ba96052747388b5801f137dd740b73fde91ad207d96baf9f17fbcc80fc1a477ad65181b5eb5fa718d27c69501d7af
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: ~0.0.3
-    webidl-conversions: ^3.0.0
-  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves: unnecessary dependencies

**Overall change:** Since `fetch` is now supported by the vast majority of devices (and has been for some time), some users of this library may not want to include a fetch ponyfill (i.e. `cross-fetch`) in their dependency bundles. This change allows clients to pass in their own ponyfill for `fetch` if they are targeting browsers that do not support `fetch`.

**Code changes:**

- Allow clients to pass in a `fetch` prop that is the fetch implementation they want to use
- The default is to use the global `fetch` function
- This will be a breaking change and so should have a major version bump

### Testing

In the WebCore Presentation layer, this reduces the bundle size by ~8kB as `cross-fetch` and its dependencies are no longer required.

---

- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] I have assigned myself to this PR and the corresponding issues
- [x] Automated jest tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
